### PR TITLE
fix for php fpm setup

### DIFF
--- a/src/Http/Controllers/HotreloadServerSentEventsController.php
+++ b/src/Http/Controllers/HotreloadServerSentEventsController.php
@@ -54,6 +54,7 @@ class HotreloadServerSentEventsController
             'Content-Type' => 'text/event-stream',
             'Cache-Control' => 'no-cache',
             'Connection' => 'keep-alive',
+            'X-Accel-Buffering' => 'no',
         ]);
     }
 


### PR DESCRIPTION
While trying to run the hot reload server in an php fpm + nginx setup noticed it was not connecting. 

Checking back at the implementation of the recent `eventStream` [in Laravel](https://github.com/laravel/framework/blob/dee10cad2e1f7debd03ee9b02339bb8c2938b326/src/Illuminate/Routing/ResponseFactory.php#L130) noticed this flag, once added, it began to work as expected.