### PR TITLE
Use the Laravel 12's Server-Sent Events Implementation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,10 +15,8 @@ jobs:
       fail-fast: true
       matrix:
         php: [8.3, 8.4]
-        laravel: [11.*, 12.*]
+        laravel: [12.*]
         include:
-          - laravel: 11.*
-            dependencies: "laravel/framework:11.*"
           - laravel: 12.*
             dependencies: "laravel/framework:12.*"
 

--- a/composer.json
+++ b/composer.json
@@ -15,12 +15,12 @@
         }
     ],
     "require-dev": {
-        "orchestra/testbench-dusk": "^9.11|^10.0",
+        "orchestra/testbench-dusk": "^10.0",
         "tightenco/duster": "^3.1"
     },
     "require": {
-        "illuminate/support": "^11.36|^12.0",
-        "illuminate/http": "^11.36|^12.0"
+        "illuminate/support": "^12.4",
+        "illuminate/http": "^12.4"
     },
     "suggest": {
         "ext-inotify": "Required for a better performance."

--- a/src/Hotreload.php
+++ b/src/Hotreload.php
@@ -83,6 +83,11 @@ class Hotreload
         static::$htmlPaths = static::defaultPaths('html');
     }
 
+    public static function getConfiguredWatcher(): string
+    {
+        return config('hotwire-hotreload.watcher', extension_loaded('inotify') ? 'inotify' : 'simple');
+    }
+
     protected static function defaultPaths(string $type): array
     {
         return [
@@ -101,11 +106,11 @@ class Hotreload
 
     protected static function watcherFor(string $path, Closure $onChange): FileWatcher
     {
-        if (config('hotwire-hotreload.watcher') === 'inotify' && ! extension_loaded('inotify')) {
+        if (static::getConfiguredWatcher() === 'inotify' && ! extension_loaded('inotify')) {
             throw HotreloadException::inotifyExtensionMissing();
         }
 
-        return match (config('hotwire-hotreload.watcher', extension_loaded('inotify') ? 'inotify' : 'simple')) {
+        return match (static::getConfiguredWatcher()) {
             'inotify' => new InotifyFileWatcher($path, $onChange),
             default => new SimpleFileWatcher($path, $onChange),
         };


### PR DESCRIPTION
### Changed

- Swap our custom implementation for the one in Laravel 12. This requires dropping the Laravel 11 implementation, but that should be fine. Folks using the package on L11 can still install the previous versions.