### PR TITLE
Adds Content-Type to files to /hotwired-laravel-hotreload/*

### DIFF
--- a/src/HotreloadServiceProvider.php
+++ b/src/HotreloadServiceProvider.php
@@ -45,7 +45,13 @@ class HotreloadServiceProvider extends ServiceProvider
     private function serveFile(string $file): Closure
     {
         return function () use ($file) {
-            return Response::file($file);
+            return Response::file($file, [
+                'Content-Type' => match ((string) str($file)->afterLast('.')) {
+                    'js' => 'text/javascript',
+                    'map' => 'application/json',
+                    default => 'text/plain',
+                },
+            ]);
         };
     }
 


### PR DESCRIPTION
## Notes
Encountered the following issue
```
Refused to execute script from '/hotwired-laravel-hotreload/hotreload.js?v=8a8889d3' because its MIME type ('text/plain') is not executable, and strict MIME type checking is enabled.
```
Adding the `Content-Type` resolve the issue.