### PR TITLE
Adds small config

### DIFF
--- a/config/hotreload.php
+++ b/config/hotreload.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'enabled' => env('HOTRELOAD_ENABLED', true),
+];

--- a/src/HotreloadServiceProvider.php
+++ b/src/HotreloadServiceProvider.php
@@ -12,8 +12,19 @@ use Illuminate\Support\ServiceProvider;
 
 class HotreloadServiceProvider extends ServiceProvider
 {
+    public function register()
+    {
+        $this->mergeConfigFrom(
+            __DIR__ . '/../config/hotreload.php', 'hotreload'
+        );
+    }
+
     public function boot()
     {
+        if (! config('hotreload.enabled')) {
+            return;
+        }
+
         $this->configureMiddleware();
         $this->configureJsFileRoutes();
         $this->configureServerSentEventsRoute();


### PR DESCRIPTION
## Changes
Adds a small config to explicitly turn off/on the registration of the middleware and watcher. Similar to how [Telescope registers](https://github.com/laravel/telescope/blob/357f075340b0429fe8e5d096d96854b5fdfc9433/src/TelescopeServiceProvider.php#L26-L28) does things.

### Notes
Ran into a quirk behavior when using the pest browser testing plugin where due to the `while true` the pest browser test would hang, still unsure if this is due to AM PHP hanging due to the while true or if it's due to the `PHP_CLI_SERVER_WORKERS` not properly getting trickled down.